### PR TITLE
[Chore] #7 - 탭 바 뒤에 백그라운드 뷰 추가

### DIFF
--- a/Aladin-iOS/Aladin-iOS/Screens/TabBar/MainTBC.swift
+++ b/Aladin-iOS/Aladin-iOS/Screens/TabBar/MainTBC.swift
@@ -7,12 +7,19 @@
 
 import UIKit
 
+import SnapKit
+
 final class MainTBC: UITabBarController {
     
     // MARK: - Properties
+    
     private var freshLaunch = true
     private let tabBarHeight: CGFloat = 96
     private let tabBarWidth: CGFloat = 270
+    
+    // MARK: - UI
+    
+    private let containerView = UIView()
 
     // MARK: - View Life Cycle
 
@@ -25,6 +32,7 @@ final class MainTBC: UITabBarController {
         super.viewDidLoad()
         setViewControllers()
         setTabBar()
+        setTabBackground()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -79,6 +87,19 @@ final class MainTBC: UITabBarController {
         tabBar.backgroundColor = .white
         tabBar.tintColor = .aladinBlue
         tabBar.unselectedItemTintColor = .black
+    }
+    
+    private func setTabBackground() {
+        let safeHeight = view.safeAreaInsets.bottom
+        containerView.backgroundColor = .white
+
+        view.addSubview(containerView)
+        self.view.bringSubviewToFront(self.tabBar)
+        
+        containerView.snp.makeConstraints { make in
+            make.leading.trailing.bottom.equalToSuperview()
+            make.height.equalTo(safeHeight + tabBarHeight)
+        }
     }
 
     private func makeNavigationController(unselectedImage: UIImage?, selectedImage: UIImage?, rootViewController: UIViewController) -> UINavigationController {

--- a/Aladin-iOS/Aladin-iOS/Screens/TabBar/MainTBC.swift
+++ b/Aladin-iOS/Aladin-iOS/Screens/TabBar/MainTBC.swift
@@ -20,6 +20,7 @@ final class MainTBC: UITabBarController {
     // MARK: - UI
     
     private let containerView = UIView()
+    private let horizontalLine = UIView()
 
     // MARK: - View Life Cycle
 
@@ -92,13 +93,22 @@ final class MainTBC: UITabBarController {
     private func setTabBackground() {
         let safeHeight = view.safeAreaInsets.bottom
         containerView.backgroundColor = .white
-
-        view.addSubview(containerView)
-        self.view.bringSubviewToFront(self.tabBar)
+        horizontalLine.backgroundColor = .aladinGray1
         
+        view.addSubviews(horizontalLine, containerView)
+        
+        self.view.bringSubviewToFront(self.tabBar)
+        self.view.bringSubviewToFront(self.horizontalLine)
+
         containerView.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
             make.height.equalTo(safeHeight + tabBarHeight)
+        }
+        
+        horizontalLine.snp.makeConstraints { make in
+            make.top.equalTo(containerView).inset(1)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(1)
         }
     }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- chore/#7

👷 **작업한 내용**
- 커스텀 탭 바 뒤에 잘리는 부분이 없도록 간단히 화이트 백그라운드 뷰 추가했습니다
- 구분선도 추가했습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능| 스크린샷|
|:--:|:--:|
| 홈 뷰(배경색 임의) |<img src = "https://user-images.githubusercontent.com/80062632/202475135-612414ab-4ada-4f96-924f-881bc04d7166.png" width ="300">|

## 📟 관련 이슈
- Resolved: #7
