### PR TITLE
[Feat] #15- 네트워크 세팅 및 상세페이지 좋아요 api 연결

### DIFF
--- a/Aladin-iOS/Aladin-iOS.xcodeproj/project.pbxproj
+++ b/Aladin-iOS/Aladin-iOS.xcodeproj/project.pbxproj
@@ -35,13 +35,19 @@
 		8E7984E22923815C00EDC6E3 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 8E7984E12923815C00EDC6E3 /* Then */; };
 		8E7984E52923816A00EDC6E3 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8E7984E42923816A00EDC6E3 /* SnapKit */; };
 		8E7984E82923818900EDC6E3 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 8E7984E72923818900EDC6E3 /* Moya */; };
-		A305F36F2930889D00FDF5DD /* ListTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F36E2930889D00FDF5DD /* ListTVC.swift */; };
-		A305F37129308C3300FDF5DD /* ListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F37029308C3300FDF5DD /* ListModel.swift */; };
+		8EE879B22931F065005F7AEC /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879B12931F065005F7AEC /* APIConstants.swift */; };
+		8EE879B42931F0D0005F7AEC /* BookRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879B32931F0D0005F7AEC /* BookRouter.swift */; };
+		8EE879B62931F0DE005F7AEC /* BasketRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879B52931F0DE005F7AEC /* BasketRouter.swift */; };
+		8EE879B82931F0E6005F7AEC /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879B72931F0E6005F7AEC /* Encodable+.swift */; };
+		8EE879BA2931F0EC005F7AEC /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879B92931F0EC005F7AEC /* NetworkLoggerPlugin.swift */; };
+		8EE879BC2931FD8A005F7AEC /* BookLikeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE879BB2931FD8A005F7AEC /* BookLikeResponseDTO.swift */; };
 		A305F3602927999200FDF5DD /* EditerChoiceContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F35F2927999200FDF5DD /* EditerChoiceContainerView.swift */; };
 		A305F36229279E8700FDF5DD /* BookCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F36129279E8700FDF5DD /* BookCVC.swift */; };
 		A305F369292D6DCF00FDF5DD /* HotBookContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F368292D6DCF00FDF5DD /* HotBookContainerView.swift */; };
 		A305F36B292D730400FDF5DD /* HotBookCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F36A292D730400FDF5DD /* HotBookCVC.swift */; };
 		A305F36D292DF31D00FDF5DD /* HotBookModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F36C292DF31D00FDF5DD /* HotBookModel.swift */; };
+		A305F36F2930889D00FDF5DD /* ListTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F36E2930889D00FDF5DD /* ListTVC.swift */; };
+		A305F37129308C3300FDF5DD /* ListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A305F37029308C3300FDF5DD /* ListModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,13 +78,19 @@
 		8E7984D82923788500EDC6E3 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		8E7984DC29237E5200EDC6E3 /* ColorLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLiterals.swift; sourceTree = "<group>"; };
 		8E7984DE29237FB100EDC6E3 /* ImageLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLiterals.swift; sourceTree = "<group>"; };
-		A305F36E2930889D00FDF5DD /* ListTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTVC.swift; sourceTree = "<group>"; };
-		A305F37029308C3300FDF5DD /* ListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModel.swift; sourceTree = "<group>"; };
+		8EE879B12931F065005F7AEC /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		8EE879B32931F0D0005F7AEC /* BookRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookRouter.swift; sourceTree = "<group>"; };
+		8EE879B52931F0DE005F7AEC /* BasketRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasketRouter.swift; sourceTree = "<group>"; };
+		8EE879B72931F0E6005F7AEC /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
+		8EE879B92931F0EC005F7AEC /* NetworkLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPlugin.swift; sourceTree = "<group>"; };
+		8EE879BB2931FD8A005F7AEC /* BookLikeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookLikeResponseDTO.swift; sourceTree = "<group>"; };
 		A305F35F2927999200FDF5DD /* EditerChoiceContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditerChoiceContainerView.swift; sourceTree = "<group>"; };
 		A305F36129279E8700FDF5DD /* BookCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookCVC.swift; sourceTree = "<group>"; };
 		A305F368292D6DCF00FDF5DD /* HotBookContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotBookContainerView.swift; sourceTree = "<group>"; };
 		A305F36A292D730400FDF5DD /* HotBookCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotBookCVC.swift; sourceTree = "<group>"; };
 		A305F36C292DF31D00FDF5DD /* HotBookModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotBookModel.swift; sourceTree = "<group>"; };
+		A305F36E2930889D00FDF5DD /* ListTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTVC.swift; sourceTree = "<group>"; };
+		A305F37029308C3300FDF5DD /* ListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,10 +160,9 @@
 		8E7984BC29235F8300EDC6E3 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				8E7984C42923601C00EDC6E3 /* API */,
-				8E7984C52923602400EDC6E3 /* Service */,
-				8E7984C32923601700EDC6E3 /* Model */,
-				8E7984C22923600F00EDC6E3 /* Foundation */,
+				8E7984C42923601C00EDC6E3 /* Base */,
+				8E7984C52923602400EDC6E3 /* Router */,
+				8E7984C22923600F00EDC6E3 /* DTO */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -211,32 +222,31 @@
 			path = Basket;
 			sourceTree = "<group>";
 		};
-		8E7984C22923600F00EDC6E3 /* Foundation */ = {
+		8E7984C22923600F00EDC6E3 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				8EE879BB2931FD8A005F7AEC /* BookLikeResponseDTO.swift */,
 			);
-			path = Foundation;
+			path = DTO;
 			sourceTree = "<group>";
 		};
-		8E7984C32923601700EDC6E3 /* Model */ = {
+		8E7984C42923601C00EDC6E3 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				8EE879B12931F065005F7AEC /* APIConstants.swift */,
+				8EE879B72931F0E6005F7AEC /* Encodable+.swift */,
+				8EE879B92931F0EC005F7AEC /* NetworkLoggerPlugin.swift */,
 			);
-			path = Model;
+			path = Base;
 			sourceTree = "<group>";
 		};
-		8E7984C42923601C00EDC6E3 /* API */ = {
+		8E7984C52923602400EDC6E3 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				8EE879B32931F0D0005F7AEC /* BookRouter.swift */,
+				8EE879B52931F0DE005F7AEC /* BasketRouter.swift */,
 			);
-			path = API;
-			sourceTree = "<group>";
-		};
-		8E7984C52923602400EDC6E3 /* Service */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Service;
+			path = Router;
 			sourceTree = "<group>";
 		};
 		8E7984C62923602E00EDC6E3 /* Supports */ = {
@@ -396,6 +406,7 @@
 				A305F3602927999200FDF5DD /* EditerChoiceContainerView.swift in Sources */,
 				8E7984DD29237E5300EDC6E3 /* ColorLiterals.swift in Sources */,
 				A305F369292D6DCF00FDF5DD /* HotBookContainerView.swift in Sources */,
+				8EE879B62931F0DE005F7AEC /* BasketRouter.swift in Sources */,
 				A305F36229279E8700FDF5DD /* BookCVC.swift in Sources */,
 				140A387A292BD81D00208C8D /* ReviewModel.swift in Sources */,
 				8E7984D0292368B700EDC6E3 /* HomeVC.swift in Sources */,
@@ -410,9 +421,14 @@
 				8E333AA0292293FF003E08B4 /* SceneDelegate.swift in Sources */,
 				A305F37129308C3300FDF5DD /* ListModel.swift in Sources */,
 				A305F36B292D730400FDF5DD /* HotBookCVC.swift in Sources */,
+				8EE879B22931F065005F7AEC /* APIConstants.swift in Sources */,
 				140A38852930A04C00208C8D /* BasketFooterView.swift in Sources */,
+				8EE879BC2931FD8A005F7AEC /* BookLikeResponseDTO.swift in Sources */,
 				8E4FE7AD292381F600E9F36A /* Adjusted+.swift in Sources */,
+				8EE879BA2931F0EC005F7AEC /* NetworkLoggerPlugin.swift in Sources */,
+				8EE879B82931F0E6005F7AEC /* Encodable+.swift in Sources */,
 				8E4FE7B12923823400E9F36A /* getClassName.swift in Sources */,
+				8EE879B42931F0D0005F7AEC /* BookRouter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aladin-iOS/Aladin-iOS/Network/Base/APIConstants.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/Base/APIConstants.swift
@@ -1,0 +1,25 @@
+//
+//  APIConstants.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation
+
+struct APIConstants {
+    
+    // MARK: - Base URL
+    
+    static let baseURL = "http://13.124.216.89:3000/api"
+    
+    // MARK: - Book
+    
+    static let book = "/book"
+    
+    // MARK: - Basket
+    
+    static let basket = "/basket"
+
+
+}

--- a/Aladin-iOS/Aladin-iOS/Network/Base/Encodable+.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/Base/Encodable+.swift
@@ -1,0 +1,23 @@
+//
+//  Encodable+.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation
+
+// MARK: - Encodable Extension
+
+extension Encodable {
+    
+    func asParameter() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+                as? [String: Any] else {
+            throw NSError()
+        }
+        
+        return dictionary
+    }
+}

--- a/Aladin-iOS/Aladin-iOS/Network/Base/NetworkLoggerPlugin.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/Base/NetworkLoggerPlugin.swift
@@ -1,0 +1,123 @@
+//
+//  NetworkLoggerPlugin.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation
+
+import Moya
+
+/// Logs network activity (outgoing requests and incoming responses).
+public final class NetworkLoggerPlugin: PluginType {
+    fileprivate let loggerId = "Moya_Logger"
+    fileprivate let dateFormatString = "dd/MM/yyyy HH:mm:ss"
+    fileprivate let dateFormatter = DateFormatter()
+    fileprivate let separator = ", "
+    fileprivate let terminator = "\n"
+    fileprivate let cURLTerminator = "\\\n"
+    fileprivate let output: (_ separator: String, _ terminator: String, _ items: Any...) -> Void
+    fileprivate let requestDataFormatter: ((Data) -> (String))?
+    fileprivate let responseDataFormatter: ((Data) -> (Data))?
+    
+    /// A Boolean value determing whether response body data should be logged.
+    public let isVerbose: Bool
+    public let cURL: Bool
+    
+    /// Initializes a NetworkLoggerPlugin.
+    public init(verbose: Bool = true, cURL: Bool = false, output: ((_ separator: String, _ terminator: String, _ items: Any...) -> Void)? = nil, requestDataFormatter: ((Data) -> (String))? = nil, responseDataFormatter: ((Data) -> (Data))? = nil) {
+        self.cURL = cURL
+        self.isVerbose = verbose
+        self.output = output ?? NetworkLoggerPlugin.reversedPrint
+        self.requestDataFormatter = requestDataFormatter
+        self.responseDataFormatter = responseDataFormatter
+    }
+    
+    public func willSend(_ request: RequestType, target: TargetType) {
+        if let request = request as? CustomDebugStringConvertible, cURL {
+            output(separator, terminator, request.debugDescription)
+            return
+        }
+        outputItems(logNetworkRequest(request.request as URLRequest?))
+    }
+    
+    public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
+        if case .success(let response) = result {
+            outputItems(logNetworkResponse(response.response, data: response.data, target: target))
+        } else {
+            print(result)
+            outputItems(logNetworkResponse(nil, data: nil, target: target))
+        }
+    }
+    
+    fileprivate func outputItems(_ items: [String]) {
+        if isVerbose {
+            items.forEach { output(separator, terminator, $0) }
+        } else {
+            output(separator, terminator, items)
+        }
+    }
+}
+
+private extension NetworkLoggerPlugin {
+    
+    var date: String {
+        dateFormatter.dateFormat = dateFormatString
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        return dateFormatter.string(from: Date())
+    }
+    
+    func format(_ loggerId: String, date: String, identifier: String, message: String) -> String {
+        return "\(loggerId): [\(date)] \(identifier): \(message)"
+    }
+    
+    func logNetworkRequest(_ request: URLRequest?) -> [String] {
+        
+        var output = [String]()
+        
+        output += [format(loggerId, date: date, identifier: "Request", message: request?.description ?? "(invalid request)")]
+        
+        if let headers = request?.allHTTPHeaderFields {
+            output += [format(loggerId, date: date, identifier: "Request Headers", message: headers.description)]
+        }
+        
+        if let bodyStream = request?.httpBodyStream {
+            output += [format(loggerId, date: date, identifier: "Request Body Stream", message: bodyStream.description)]
+        }
+        
+        if let httpMethod = request?.httpMethod {
+            output += [format(loggerId, date: date, identifier: "HTTP Request Method", message: httpMethod)]
+        }
+        
+        if let body = request?.httpBody, let stringOutput = requestDataFormatter?(body) ?? String(data: body, encoding: .utf8), isVerbose {
+            output += [format(loggerId, date: date, identifier: "Request Body", message: stringOutput)]
+        }
+        
+        return output
+    }
+    
+    func logNetworkResponse(_ response: HTTPURLResponse?, data: Data?, target: TargetType) -> [String] {
+        guard let response = response else {
+            return [format(loggerId, date: date, identifier: "Response", message: "Received empty network response for \(target).")]
+        }
+        
+        var output = [String]()
+        output += [format(loggerId, date: date, identifier: "Response", message: response.description)]
+        
+        if let data = data, let stringData = String(data: responseDataFormatter?(data) ?? data, encoding: String.Encoding.utf8), isVerbose {
+            output += [stringData]
+        }
+        
+        return output
+    }
+}
+
+fileprivate extension NetworkLoggerPlugin {
+    static func reversedPrint(_ separator: String, terminator: String, items: Any...) {
+        for item in items {
+            print(item, separator: separator, terminator: terminator)
+        }
+    }
+}
+

--- a/Aladin-iOS/Aladin-iOS/Network/DTO/BookLikeResponseDTO.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/DTO/BookLikeResponseDTO.swift
@@ -1,0 +1,28 @@
+//
+//  BookLikeResponseDTO.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation
+
+struct BookLikeResponseDTO: Codable {
+    let status: Int
+    let success: Bool?
+    let message: String
+    let data: DataClass
+}
+
+// MARK: - DataClass
+struct DataClass: Codable {
+    let id, userID, bookID, likeCount: Int
+    let hasLike: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userID = "user_id"
+        case bookID = "book_id"
+        case likeCount, hasLike
+    }
+}

--- a/Aladin-iOS/Aladin-iOS/Network/Router/BasketRouter.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/Router/BasketRouter.swift
@@ -1,0 +1,8 @@
+//
+//  BasketRouter.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation

--- a/Aladin-iOS/Aladin-iOS/Network/Router/BookRouter.swift
+++ b/Aladin-iOS/Aladin-iOS/Network/Router/BookRouter.swift
@@ -1,0 +1,48 @@
+//
+//  BookRouter.swift
+//  Aladin-iOS
+//
+//  Created by devxsby on 2022/11/26.
+//
+
+import Foundation
+
+import Moya
+
+enum BookRouter {
+    case fetchBookLike(bookId: Int)
+}
+
+extension BookRouter: TargetType {
+    var baseURL: URL {
+        return URL(string: APIConstants.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchBookLike(let bookId):
+            return "\(APIConstants.book)/\(bookId)/like"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchBookLike:
+            return .put
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .fetchBookLike(let bookId):
+            return .requestParameters(parameters: [
+                "bookId": bookId], encoding: URLEncoding.queryString)
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json",
+                "userId": "2"]
+    }
+    
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#15

👷 **작업한 내용**
- 프로젝트 세팅하고 상세 페이지 좋아요 api 연결했습니다.
- 명세서 보고 라우터만 book, basket 나눠서 안에 enum 케이스로 넣어서 작업해주시고, request, response파일은 각자 따로 만들어서 작업하기로 해요 (ex. getBookList, getBookDetail, postBasketList 등)

## 🚨참고 사항
- 상세보기 api를 안붙여놔서 하트 카운트 수 증가는 라벨에 반영 안시켰어요~

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF| ![Simulator Screen Recording - iPhone 14 Pro - 2022-11-28 at 00 25 56](https://user-images.githubusercontent.com/80062632/204143283-e31a294c-7485-4459-ab44-a9149612e96d.gif)|

## 📟 관련 이슈
- Resolved: #15
